### PR TITLE
fix: invalid `date` in tepitech chart error

### DIFF
--- a/src/Pages/TEPitech.js
+++ b/src/Pages/TEPitech.js
@@ -25,7 +25,7 @@ const ShowChart = ({ tepitechs }) => {
 
     if (!tepitechs) return renderSkeletons();
     const chartData = tepitechs.map((tepitech) => ({
-        x: new Date(tepitech.date).toLocaleDateString(),
+        x: new Date(tepitech.date),
         y: tepitech.final_note,
     }));
 


### PR DESCRIPTION
## Summary

This PR fixes an issue with the `tepitech` tab where the charts are not rendered correctly due to an invalid date. The straightforward fix is using a correct date.

## Before

![image](https://github.com/RedBoardDev/EpitechIntranetStatistics/assets/74559859/660bffb3-4552-47df-b4dd-b85904605d63)

![image](https://github.com/RedBoardDev/EpitechIntranetStatistics/assets/74559859/6949fea7-32a4-49e4-be17-1da5d2140352)

## After

![image](https://github.com/RedBoardDev/EpitechIntranetStatistics/assets/74559859/83555260-3ae6-4ecc-80af-f43cdb8f96eb)

